### PR TITLE
Swap defunct tightenco/collection with illuminate/collections

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
   "require": {
     "php": "^8.1",
     "nesbot/carbon": "^2.65",
-    "tightenco/collect": "^9.0"
+    "illuminate/collections": "^11.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.0",

--- a/src/RecurringBuilder.php
+++ b/src/RecurringBuilder.php
@@ -11,7 +11,7 @@ use PhpRecurring\Traits\DateMatch;
 use PhpRecurring\Traits\GenerateDates;
 use PhpRecurring\Traits\GenerateEndDate;
 use PhpRecurring\Traits\ShouldGenerate;
-use Tightenco\Collect\Support\Collection;
+use Illuminate\Support\Collection;
 
 class RecurringBuilder
 {

--- a/src/RecurringConfig.php
+++ b/src/RecurringConfig.php
@@ -12,7 +12,7 @@ use PhpRecurring\Exceptions\InvalidFrequencyEndValue;
 use PhpRecurring\Exceptions\InvalidFrequencyInterval;
 use PhpRecurring\Exceptions\InvalidRepeatedCount;
 use PhpRecurring\Exceptions\InvalidRepeatIn;
-use Tightenco\Collect\Support\Collection;
+use Illuminate\Support\Collection;
 
 class RecurringConfig
 {

--- a/src/Traits/DateMatch.php
+++ b/src/Traits/DateMatch.php
@@ -8,7 +8,7 @@ use Carbon\Carbon;
 use PhpRecurring\Enums\FrequencyTypeEnum;
 use PhpRecurring\Enums\WeekdayEnum;
 use PhpRecurring\RecurringConfig;
-use Tightenco\Collect\Support\Collection;
+use Illuminate\Support\Collection;
 
 trait DateMatch
 {

--- a/src/Traits/GenerateDates.php
+++ b/src/Traits/GenerateDates.php
@@ -7,7 +7,7 @@ use PhpRecurring\Enums\FrequencyEndTypeEnum;
 use PhpRecurring\Enums\FrequencyTypeEnum;
 use PhpRecurring\Exceptions\InvalidFrequencyEndValue;
 use PhpRecurring\RecurringConfig;
-use Tightenco\Collect\Support\Collection;
+use Illuminate\Support\Collection;
 
 trait GenerateDates
 {

--- a/src/Traits/ShouldGenerate.php
+++ b/src/Traits/ShouldGenerate.php
@@ -7,7 +7,7 @@ namespace PhpRecurring\Traits;
 use Carbon\Carbon;
 use PhpRecurring\Enums\FrequencyEndTypeEnum;
 use PhpRecurring\RecurringConfig;
-use Tightenco\Collect\Support\Collection;
+use Illuminate\Support\Collection;
 
 trait ShouldGenerate
 {

--- a/tests/DateMatchTest.php
+++ b/tests/DateMatchTest.php
@@ -9,7 +9,7 @@ use PhpRecurring\Enums\FrequencyEndTypeEnum;
 use PhpRecurring\Enums\FrequencyTypeEnum;
 use PhpRecurring\Enums\WeekdayEnum;
 use PhpRecurring\RecurringConfig;
-use Tightenco\Collect\Support\Collection;
+use Illuminate\Support\Collection;
 
 class DateMatchTest extends AbstractTestCase
 {

--- a/tests/GenerateDatesTest.php
+++ b/tests/GenerateDatesTest.php
@@ -8,7 +8,7 @@ use PhpRecurring\Enums\FrequencyTypeEnum;
 use PhpRecurring\Enums\WeekdayEnum;
 use PhpRecurring\Exceptions\InvalidFrequencyEndValue;
 use PhpRecurring\RecurringConfig;
-use Tightenco\Collect\Support\Collection;
+use Illuminate\Support\Collection;
 
 class GenerateDatesTest extends AbstractTestCase
 {

--- a/tests/ShouldGenerateTest.php
+++ b/tests/ShouldGenerateTest.php
@@ -8,7 +8,7 @@ use Carbon\Carbon;
 use PhpRecurring\Enums\FrequencyEndTypeEnum;
 use PhpRecurring\Enums\FrequencyTypeEnum;
 use PhpRecurring\RecurringConfig;
-use Tightenco\Collect\Support\Collection;
+use Illuminate\Support\Collection;
 
 class ShouldGenerateTest extends AbstractTestCase
 {

--- a/tests/ShouldIncludeStartDateTest.php
+++ b/tests/ShouldIncludeStartDateTest.php
@@ -10,7 +10,7 @@ use PhpRecurring\Enums\FrequencyTypeEnum;
 use PhpRecurring\Enums\WeekdayEnum;
 use PhpRecurring\Exceptions\InvalidExceptDate;
 use PhpRecurring\RecurringConfig;
-use Tightenco\Collect\Support\Collection;
+use Illuminate\Support\Collection;
 
 class ShouldIncludeStartDateTest extends AbstractTestCase
 {


### PR DESCRIPTION
This is an in-place replacement. All test pass, and functionality remains the same. 