### PR TITLE
fix: validate positive recurrence values

### DIFF
--- a/src/Actions/Configurations/ValidateRecurringConfigAction.php
+++ b/src/Actions/Configurations/ValidateRecurringConfigAction.php
@@ -62,7 +62,7 @@ class ValidateRecurringConfigAction
 
         return ($frequencyEndType !== FrequencyEndTypeEnum::NEVER && !$frequencyEndValue)
             || ($frequencyEndType === FrequencyEndTypeEnum::IN && !($frequencyEndValue instanceof Carbon))
-            || ($frequencyEndType === FrequencyEndTypeEnum::AFTER && !is_int($frequencyEndValue));
+            || ($frequencyEndType === FrequencyEndTypeEnum::AFTER && (!is_int($frequencyEndValue) || $frequencyEndValue <= 0));
     }
 
     /**
@@ -123,6 +123,7 @@ class ValidateRecurringConfigAction
 
     private function isPositiveNumeric(mixed $value): bool
     {
-        return is_int($value) || (is_string($value) && ctype_digit($value) && (int) $value > 0);
+        return (is_int($value) && $value > 0)
+            || (is_string($value) && ctype_digit($value) && (int) $value > 0);
     }
 }

--- a/tests/RecurringConfigTest.php
+++ b/tests/RecurringConfigTest.php
@@ -66,6 +66,28 @@ class RecurringConfigTest extends AbstractTestCase
         self::assertFalse($recurringConfig->isValid());
     }
 
+    public function test_invalid_frequency_end_value_after_zero_occurrences(): void
+    {
+        $recurringConfig = new RecurringConfig();
+
+        $recurringConfig->setFrequencyEndType(FrequencyEndTypeEnum::AFTER)
+            ->setFrequencyEndValue(0);
+
+        $this->expectException(InvalidFrequencyEndValue::class);
+        self::assertFalse($recurringConfig->isValid());
+    }
+
+    public function test_invalid_frequency_end_value_after_negative_occurrences(): void
+    {
+        $recurringConfig = new RecurringConfig();
+
+        $recurringConfig->setFrequencyEndType(FrequencyEndTypeEnum::AFTER)
+            ->setFrequencyEndValue(-1);
+
+        $this->expectException(InvalidFrequencyEndValue::class);
+        self::assertFalse($recurringConfig->isValid());
+    }
+
     public function test_invalid_repeated_count(): void
     {
         $recurringConfig = new RecurringConfig();
@@ -82,6 +104,50 @@ class RecurringConfigTest extends AbstractTestCase
 
         $recurringConfig->setFrequencyType(FrequencyTypeEnum::YEAR)
             ->setRepeatIn(['day' => 2, 'test' => 4]);
+
+        $this->expectException(InvalidRepeatIn::class);
+        self::assertFalse($recurringConfig->isValid());
+    }
+
+    public function test_invalid_repeat_in_year_with_zero_day(): void
+    {
+        $recurringConfig = new RecurringConfig();
+
+        $recurringConfig->setFrequencyType(FrequencyTypeEnum::YEAR)
+            ->setRepeatIn(['day' => 0, 'month' => 1]);
+
+        $this->expectException(InvalidRepeatIn::class);
+        self::assertFalse($recurringConfig->isValid());
+    }
+
+    public function test_invalid_repeat_in_year_with_negative_day(): void
+    {
+        $recurringConfig = new RecurringConfig();
+
+        $recurringConfig->setFrequencyType(FrequencyTypeEnum::YEAR)
+            ->setRepeatIn(['day' => -1, 'month' => 1]);
+
+        $this->expectException(InvalidRepeatIn::class);
+        self::assertFalse($recurringConfig->isValid());
+    }
+
+    public function test_invalid_repeat_in_year_with_zero_month(): void
+    {
+        $recurringConfig = new RecurringConfig();
+
+        $recurringConfig->setFrequencyType(FrequencyTypeEnum::YEAR)
+            ->setRepeatIn(['day' => 1, 'month' => 0]);
+
+        $this->expectException(InvalidRepeatIn::class);
+        self::assertFalse($recurringConfig->isValid());
+    }
+
+    public function test_invalid_repeat_in_year_with_negative_month(): void
+    {
+        $recurringConfig = new RecurringConfig();
+
+        $recurringConfig->setFrequencyType(FrequencyTypeEnum::YEAR)
+            ->setRepeatIn(['day' => 1, 'month' => -1]);
 
         $this->expectException(InvalidRepeatIn::class);
         self::assertFalse($recurringConfig->isValid());


### PR DESCRIPTION
## Summary

This PR tightens recurrence configuration validation so invalid non-positive values are rejected before date generation starts.

Previously, yearly recurrence settings could accept `0` or negative integer values for `repeatIn['day']` and `repeatIn['month']` because the numeric validation treated any integer as positive. The `AFTER` end condition also accepted negative occurrence limits because it only checked whether the value was an integer.

## Changes

- Reject `frequencyEndType = AFTER` when `frequencyEndValue` is less than or equal to zero.
- Reject yearly `repeatIn['day']` values less than or equal to zero.
- Reject yearly `repeatIn['month']` values less than or equal to zero.
- Keep support for positive integers and positive numeric strings where the existing API already allowed them.
- Add regression tests covering zero and negative values for both yearly recurrence fields and `AFTER` occurrence limits.

## Why

These values do not represent valid recurrence rules:

- `AFTER 0` occurrences cannot generate a meaningful recurrence.
- `AFTER -1` occurrences is invalid.
- Yearly recurrence day/month values must be positive calendar values.

Rejecting them during configuration validation keeps invalid recurrence rules from being accepted silently and makes the behavior consistent with the existing monthly validation rules.

## Validation

I ran the project checks locally:

```bash
composer test
composer analyse
composer lint
```

Results:

- PHPUnit: 56 tests, 187 assertions passing
- PHPStan: no errors
- PHP CS Fixer dry run: no fixable files

Note: PHPUnit reported one existing deprecation warning from the current test configuration/runtime, but the test suite passed successfully.